### PR TITLE
Fix activity stats month grouping bug

### DIFF
--- a/src/components/chart/ActivityStatsChart.tsx
+++ b/src/components/chart/ActivityStatsChart.tsx
@@ -17,7 +17,7 @@ const ActivityStatsChart = () => {
   events.forEach((activity) => {
     if (activity.status === 'pending') return;
 
-    const monthKey = dayjs(activity.date).format('YYYY-MM');
+    const monthKey = dayjs(activity.start_date).format('YYYY-MM');
     if (!statsByMonth[monthKey]) {
       statsByMonth[monthKey] = { done: 0, skipped: 0 };
     }


### PR DESCRIPTION
## Summary
- fix ActivityStatsChart to use `start_date` instead of undefined `date`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: Cannot find module 'vite')*

------
https://chatgpt.com/codex/tasks/task_e_683fde6f1d24832f8943a15965a7c6da